### PR TITLE
Redid how Subfolders are handled

### DIFF
--- a/StaticWikiCore/StaticWikiCore.cs
+++ b/StaticWikiCore/StaticWikiCore.cs
@@ -13,7 +13,7 @@ namespace StaticWiki
     {
         private const string NavigationFileName = "Navigation";
         private const string SourceFilesExtension = "md";
-        private static readonly string[] NonModifiedPaths = { "http" }; // Values that won't get modified to fix path issues (Example: *http*s://www.google.com)
+        private static readonly string[] NonModifiedPaths = { "http://", "https://" }; // Values that won't get modified to fix path issues (Example: *http*s://www.google.com)
 
         private class FileInfo
         {
@@ -133,7 +133,7 @@ namespace StaticWiki
                 bool hasNonModifiedStrings = false;
                 foreach (string nonModify in NonModifiedPaths)
                     {
-                        hasNonModifiedStrings = Regex.Match(navigationPath, nonModify).Success;
+                        hasNonModifiedStrings = Regex.Match(navigationPath.Substring(0, nonModify.Length), nonModify).Success;
                     }
 
                 if (!hasNonModifiedStrings)

--- a/StaticWikiCore/StaticWikiCore.cs
+++ b/StaticWikiCore/StaticWikiCore.cs
@@ -13,6 +13,7 @@ namespace StaticWiki
     {
         private const string NavigationFileName = "Navigation";
         private const string SourceFilesExtension = "md";
+        private static readonly string[] NonModifiedPaths = { "http" }; // Values that won't get modified to fix path issues (Example: *http*s://www.google.com)
 
         private class FileInfo
         {
@@ -128,8 +129,21 @@ namespace StaticWiki
                     continue;
                 }
 
-                outNavigation.Add(new KeyValuePair<string, string>(pieces[0].Replace("\n", "").Replace("\r", "").Trim(),
-                    recursivePath + pieces[1].Replace("\n", "").Replace("\r", "").Trim()));
+                var navigationPath = pieces[1].Replace("\n", "").Replace("\r", "").Trim();
+                bool hasNonModifiedStrings = false;
+                foreach (string nonModify in NonModifiedPaths)
+                    {
+                        hasNonModifiedStrings = Regex.Match(navigationPath, nonModify).Success;
+                    }
+
+                if (!hasNonModifiedStrings)
+                {
+                    outNavigation.Add(new KeyValuePair<string, string>(pieces[0].Replace("\n", "").Replace("\r", "").Trim(), recursivePath + navigationPath));
+                }
+                else
+                {
+                    outNavigation.Add(new KeyValuePair<string, string>(pieces[0].Replace("\n", "").Replace("\r", "").Trim(), navigationPath));
+                }
             }
 
             return outNavigation;

--- a/StaticWikiCore/StaticWikiCore.cs
+++ b/StaticWikiCore/StaticWikiCore.cs
@@ -13,7 +13,7 @@ namespace StaticWiki
     {
         private const string NavigationFileName = "Navigation";
         private const string SourceFilesExtension = "md";
-        private static readonly string[] NonModifiedPaths = { "http://", "https://" }; // Values that won't get modified to fix path issues (Example: *http*s://www.google.com)
+        private static readonly string[] NonModifiedPaths = { ":/" }; // Values that won't get modified to fix path issues (Example: *http*s://www.google.com)
 
         private class FileInfo
         {
@@ -132,9 +132,9 @@ namespace StaticWiki
                 var navigationPath = pieces[1].Replace("\n", "").Replace("\r", "").Trim();
                 bool hasNonModifiedStrings = false;
                 foreach (string nonModify in NonModifiedPaths)
-                    {
-                        hasNonModifiedStrings = Regex.Match(navigationPath.Substring(0, nonModify.Length), nonModify).Success;
-                    }
+                {
+                    hasNonModifiedStrings = Regex.Match(navigationPath, nonModify).Success;
+                }
 
                 if (!hasNonModifiedStrings)
                 {

--- a/StaticWikiHelper/MainWindow.xaml.cs
+++ b/StaticWikiHelper/MainWindow.xaml.cs
@@ -189,7 +189,7 @@ namespace StaticWikiHelper
         {
             var logMessage = "";
 
-            StaticWikiCore.ProcessDirectory(sourceDirectory, destinationDirectory, themeFileName, navigationFileName, contentExtensions, titleName, ref logMessage);
+            StaticWikiCore.ProcessSubDirectory(sourceDirectory, destinationDirectory, themeFileName, navigationFileName, contentExtensions, titleName, ref logMessage, 0);
 
             if (logMessage.Length > 0)
             {


### PR DESCRIPTION
I found that the official way to do subfolders was a bit clunky, so I made these changes instead.

The HTML file for the sub-page is modified directly via a regex in order to get the proper root folder from the subdirectory. Nothing is copied to the subdirectories as for they use the base theme file

What this changes: Now in the `md` files you can put as a link: `[subfolder link](sub1/sub2/file.html)` instead of `[subfolder link](file_sub1_sub2.html)`. In my opinion, this streamlines the process and allows for quick changes without having to find the new directory path. This also reduces bloat of the page as for the theme isn't being copied for each subdirectory.